### PR TITLE
CI: prevent duplicate triggering of build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   build_windows:
     name: Build for Windows


### PR DESCRIPTION
Builds are triggered on pushes to the repo and when a PR is updated. If a PR from a branch in the same repo is pushed to, both triggers activate, starting each job twice.
This change guards against this case.